### PR TITLE
Fix/scroll in forms

### DIFF
--- a/Bird-Modules/Sources/NewCollectionFeature/NewCollectionView.swift
+++ b/Bird-Modules/Sources/NewCollectionFeature/NewCollectionView.swift
@@ -151,6 +151,7 @@ public struct NewCollectionView: View {
             .scrollDismissesKeyboard(ScrollDismissesKeyboardMode.interactively)
         }
         .navigationViewStyle(.stack)
+        .interactiveDismissDisabled(selectedField != nil ? true : false)
         
     }
     

--- a/Bird-Modules/Sources/NewDeckFeature/NewDeckView.swift
+++ b/Bird-Modules/Sources/NewDeckFeature/NewDeckView.swift
@@ -174,6 +174,7 @@ public struct NewDeckView: View {
             .scrollDismissesKeyboard(ScrollDismissesKeyboardMode.interactively)
             .viewBackgroundColor(HBColor.primaryBackground)
         }
+        .interactiveDismissDisabled(selectedField != nil ? true : false)
         
     }
 }

--- a/Bird-Modules/Sources/NewFlashcardFeature/NewFlashcardView.swift
+++ b/Bird-Modules/Sources/NewFlashcardFeature/NewFlashcardView.swift
@@ -179,6 +179,7 @@ public struct NewFlashcardView: View {
             }
             
         }
+        .interactiveDismissDisabled(focus != nil ? true : false)
     }
 }
 


### PR DESCRIPTION
Nessa task arrumei o bug do scroll nos formulários onde ele poderiam ser dispensados enquanto o teclado estava aberto (no iPhone), o que deixava a view bugada.
Resolvi isso tornando o dispensar desabilitado enquanto o teclado estiver aberto com o comando interactiveDismissDisabled na NavigationView.