### PR TITLE
label não é mais cortada em iphones menores

### DIFF
--- a/Bird-Modules/Sources/StudyFeature/EndOfStudyView.swift
+++ b/Bird-Modules/Sources/StudyFeature/EndOfStudyView.swift
@@ -27,6 +27,7 @@ struct EndOfStudyView: View {
                 .bold()
                 .font(.system(size: 32))
                 .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
                 .padding()
             
             HBAssets.endOfStudy


### PR DESCRIPTION
A label de estudo concluído estava sendo cortada (com ...) em iphones menores.
Consertei com _.fixedSize(horizontal: false, vertical: true)_ no Text