### PR TITLE
Feat/i pad notes fixes

### DIFF
--- a/Bird-Modules/Sources/AppFeature/Detail/DeckGridView.swift
+++ b/Bird-Modules/Sources/AppFeature/Detail/DeckGridView.swift
@@ -24,7 +24,6 @@ struct DeckGridView: View {
                 ForEach(sortedDecks) { deck in
                     NavigationLink(value: StudyRoute.deck(deck)) {
                         DeckCell(info: DeckCellInfo(deck: deck))
-                        .buttonStyle(DeckCell.Style(color: deck.color))
                         .contextMenu {
                             Button {
                                 editAction(deck)
@@ -39,7 +38,9 @@ struct DeckGridView: View {
                             }
                         }
                     }
-                    .hoverEffect(.lift)
+                    .buttonStyle(DeckCell.Style(color: deck.color))
+                    .padding(2)
+                    .hoverEffect()
                 }
             }
             .animation(.linear, value: viewModel.sortOrder)

--- a/Bird-Modules/Sources/AppFeature/Detail/DeckTableView.swift
+++ b/Bird-Modules/Sources/AppFeature/Detail/DeckTableView.swift
@@ -72,8 +72,20 @@ struct DeckTableView: View {
     @ViewBuilder
     private var table: some View {
         Table(sortedDecks, selection: $viewModel.selection, sortOrder: $viewModel.sortOrder) {
+            TableColumn("") { deck in
+                Image(systemName: deck.icon)
+                    .font(.system(size: 14))
+                    .foregroundColor(HBColor.color(for: deck.color))
+                    .background {
+                        Circle()
+                            .fill(HBColor.color(for: deck.color).opacity(0.2))
+                            .frame(width: 35, height: 35)
+                    }
+                    .frame(width: 35, height: 35)
+            }.width(35)
             TableColumn(NSLocalizedString("nome", bundle: .module, comment: ""), value: \.name) { deck in
-                cell(for: deck)
+                Text(deck.name)
+                    .foregroundColor(.primary)
             }
             TableColumn("Flashcards", value: \.cardCount) { deck in
                 Text("\(deck.cardCount) flashcards")

--- a/Bird-Modules/Sources/AppFeature/Detail/DetailView.swift
+++ b/Bird-Modules/Sources/AppFeature/Detail/DetailView.swift
@@ -21,6 +21,7 @@ public struct DetailView: View {
     @State private var presentDeckEdition = false
     @State private var shouldDisplayAlert = false
     @State private var editingDeck: Deck?
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     
     init(editMode: Binding<EditMode>) {
         self._editMode = editMode
@@ -34,7 +35,7 @@ public struct DetailView: View {
                 content
             }
         }
-        .searchable(text: $viewModel.searchText, placement: .navigationBarDrawer(displayMode: .always))
+        .searchable(text: $viewModel.searchText, placement: horizontalSizeClass == .compact ? .navigationBarDrawer(displayMode: .always) : .toolbar)
         .toolbar(editMode.isEditing ? .visible : .hidden,
                  for: .bottomBar)
         .toolbar {

--- a/Bird-Modules/Sources/DeckFeature/DeckView.swift
+++ b/Bird-Modules/Sources/DeckFeature/DeckView.swift
@@ -206,7 +206,8 @@ public struct DeckView: View {
                             }
                         }
                         .frame(height: 230)
-                        .hoverEffect(.lift)
+                        .padding(2)
+                        .hoverEffect()
                     }
                     .listRowSeparator(.hidden)
                 }

--- a/Bird-Modules/Sources/HummingBird/Components/FlashcardTextEditorView.swift
+++ b/Bird-Modules/Sources/HummingBird/Components/FlashcardTextEditorView.swift
@@ -77,6 +77,7 @@ public struct FlashcardTextEditorView: View {
                 }
                 .buttonStyle(.bordered)
                 .tint(context.isItalic ? HBColor.actionColor : nil)
+                .keyboardShortcut("i", modifiers: .command)
                 
                 Button { context.isBold.toggle() } label: {
                     Image.richTextStyleBold
@@ -84,6 +85,7 @@ public struct FlashcardTextEditorView: View {
                 }
                 .buttonStyle(.bordered)
                 .tint(context.isBold ? HBColor.actionColor : nil)
+                .keyboardShortcut("b", modifiers: .command)
                 
                 Button { context.isUnderlined.toggle() } label: {
                     Image.richTextStyleUnderline
@@ -91,6 +93,7 @@ public struct FlashcardTextEditorView: View {
                 }
                 .buttonStyle(.bordered)
                 .tint(context.isUnderlined ? HBColor.actionColor : nil)
+                .keyboardShortcut("u", modifiers: .command)
 //                Button {
 //                    isPhotoPickerPresented = true
 //                } label: {
@@ -166,15 +169,23 @@ public struct FlashcardTextEditorView: View {
                 Image(systemName: "minus")
                     .frame(width: 10, height: 10)
             }
+            .keyboardShortcut("-", modifiers: .command)
             FontSizePicker(selection: size)
                 .labelsHidden()
+                .frame(minWidth: 50)
             Button {
                 context.incrementFontSize()
             } label: {
                 Image(systemName: "plus")
                     .frame(width: 10, height: 10)
             }
+            .keyboardShortcut("+", modifiers: .command)
         }
+    }
+    
+    func text(for fontSize: CGFloat) -> some View {
+        Text("\(Int(fontSize))")
+            .fixedSize(horizontal: true, vertical: false)
     }
 }
 

--- a/Bird-Modules/Sources/NewFlashcardFeature/NewFlashcardView.swift
+++ b/Bird-Modules/Sources/NewFlashcardFeature/NewFlashcardView.swift
@@ -23,6 +23,7 @@ public struct NewFlashcardView: View {
     @StateObject private var frontContext = RichTextContext()
     @StateObject private var backContext = RichTextContext()
     
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
 //    @FocusState private var focus: NewFlashcardFocus?
     
     @Environment(\.dismiss) private var dismiss
@@ -37,26 +38,27 @@ public struct NewFlashcardView: View {
     }
     
     public var body: some View {
-        
-        NavigationView {
+        NavigationStack {
             ScrollViewReader { proxy in
                 ScrollView {
                     VStack(alignment: .leading) {
-                        FlashcardTextEditorView(
-                            text: $viewModel.flashcardFront, color: HBColor.color(for: viewModel.currentSelectedColor ?? CollectionColor.darkBlue),
-                            side: NSLocalizedString("frente", bundle: .module, comment: ""),
-                            context: frontContext
-                        )
-                        .id(NewFlashcardFocus.front)
-                        .frame(minHeight: 360)
-                        
-                        FlashcardTextEditorView(
-                            text: $viewModel.flashcardBack, color: HBColor.color(for: viewModel.currentSelectedColor ?? CollectionColor.darkBlue),
-                            side: NSLocalizedString("verso", bundle: .module, comment: ""),
-                            context: backContext
-                        )
-                        .id(NewFlashcardFocus.back)
-                        .frame(minHeight: 360)
+                        layout {
+                            FlashcardTextEditorView(
+                                text: $viewModel.flashcardFront, color: HBColor.color(for: viewModel.currentSelectedColor ?? CollectionColor.darkBlue),
+                                side: NSLocalizedString("frente", bundle: .module, comment: ""),
+                                context: frontContext
+                            )
+                            .id(NewFlashcardFocus.front)
+                            .frame(minHeight: horizontalSizeClass == . compact ? 400 : 600)
+                            
+                            FlashcardTextEditorView(
+                                text: $viewModel.flashcardBack, color: HBColor.color(for: viewModel.currentSelectedColor ?? CollectionColor.darkBlue),
+                                side: NSLocalizedString("verso", bundle: .module, comment: ""),
+                                context: backContext
+                            )
+                            .id(NewFlashcardFocus.back)
+                            .frame(minHeight: horizontalSizeClass == . compact ? 400 : 600)
+                        }
                         
                         Text("cores", bundle: .module)
                             .font(.callout)
@@ -104,19 +106,32 @@ public struct NewFlashcardView: View {
                 }
                 
                 .onChange(of: frontContext.isEditingText) { newValue in
-                    if newValue {
+                    if newValue, horizontalSizeClass == .compact {
                         withAnimation {
                             proxy.scrollTo(NewFlashcardFocus.front, anchor: .center)
                         }
                     }
                 }
                 .onChange(of: backContext.isEditingText) { newValue in
-                    if newValue {
+                    if newValue, horizontalSizeClass == .compact {
                         withAnimation {
                             proxy.scrollTo(NewFlashcardFocus.back, anchor: UnitPoint(x: 0.5, y: 0.8))
                         }
                     }
                 }     
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private func layout<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        if horizontalSizeClass == .compact {
+            VStack(alignment: .leading) {
+                content()
+            }
+        } else {
+            HStack {
+                content()
             }
         }
     }

--- a/Bird-Modules/Sources/StudyFeature/FlashcardView.swift
+++ b/Bird-Modules/Sources/StudyFeature/FlashcardView.swift
@@ -29,14 +29,6 @@ struct FlashcardView: View {
             cardFace(content: viewModel.card.front, face: NSLocalizedString("frente", bundle: .module, comment: ""), description: NSLocalizedString("toque_virar", bundle: .module, comment: ""))
                 .rotation3DEffect(.degrees(frontDegree), axis: (x: 0, y: 1, z: 0.0001))
         }
-        .background(
-            Button {
-                flip()
-            } label: {
-                EmptyView()
-            }
-            .keyboardShortcut(.space, modifiers: [])
-        )
         .onTapGesture(perform: flip)
         .onChange(of: viewModel.isFlipped) { newValue in
             flipWithAnimation(newValue)


### PR DESCRIPTION
Adicionado Atalhos para iPad na tela de NewFlashcardView através do KeyboardShortcut
Adicionado um Layout alternativo para horizontalSizeClass de regular onde as Flashcards estão horizontal
Consertado o Bug onde o header da Table aparecia duplicado
Consertado bug de borda com o hoverEffect
Removido Shortcut da StudyView de Space devido ao seu comportamento não esperado