### PR TITLE
Fix/decks swipe

### DIFF
--- a/Bird-Modules/Sources/AppFeature/Detail/DeckTableView.swift
+++ b/Bird-Modules/Sources/AppFeature/Detail/DeckTableView.swift
@@ -45,6 +45,14 @@ struct DeckTableView: View {
             }
             .swipeActions {
                 Button {
+                    try? viewModel.deleteDeck(deck)
+                } label: {
+                    Text("Apagar")
+                }
+                .tint(.red)
+            }
+            .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                Button {
                     editAction(deck)
                 } label: {
                     Text("Editar")

--- a/Bird-Modules/Sources/AppFeature/Detail/DeckTableView.swift
+++ b/Bird-Modules/Sources/AppFeature/Detail/DeckTableView.swift
@@ -47,7 +47,7 @@ struct DeckTableView: View {
                 Button {
                     try? viewModel.deleteDeck(deck)
                 } label: {
-                    Text("Apagar")
+                    Text("deletar", bundle: .module)
                 }
                 .tint(.red)
             }
@@ -55,7 +55,7 @@ struct DeckTableView: View {
                 Button {
                     editAction(deck)
                 } label: {
-                    Text("Editar")
+                    Text("editar", bundle: .module)
                 }
                 .tint(HBColor.actionColor)
             }

--- a/Bird-Modules/Sources/AppFeature/Sidebar/CollectionsSidebar.swift
+++ b/Bird-Modules/Sources/AppFeature/Sidebar/CollectionsSidebar.swift
@@ -61,8 +61,7 @@ struct CollectionsSidebar: View {
                                     Image(systemName: "info.circle")
                                         .foregroundColor(HBColor.actionColor)
                                         .onTapGesture {
-                                            editingCollection = collection
-                                            presentCollectionEdition = true
+                                            editCollection(editingCollection: collection)
                                         }
                                         .accessibility(addTraits: .isButton)
                                 }
@@ -70,8 +69,7 @@ struct CollectionsSidebar: View {
                         }
                         .swipeActions(edge: .leading, allowsFullSwipe: false) {
                             Button {
-                                editingCollection = collection
-                                presentCollectionEdition = true
+                                editCollection(editingCollection: collection)
                             } label: {
                                 Text("editar", bundle: .module)
                             }
@@ -82,8 +80,7 @@ struct CollectionsSidebar: View {
                         )
                         .contextMenu {
                             Button {
-                                editingCollection = collection
-                                presentCollectionEdition = true
+                                editCollection(editingCollection: collection)
                             } label: {
                                 Label(NSLocalizedString("editar", bundle: .module, comment: ""), systemImage: "pencil")
                             }
@@ -135,8 +132,7 @@ struct CollectionsSidebar: View {
             }
             ToolbarItem {
                 Button {
-                    editingCollection = nil
-                    presentCollectionCreation = true
+                    editCollection(editingCollection: nil)
                 } label: {
                     Image(systemName: "plus")
                 }
@@ -155,13 +151,17 @@ struct CollectionsSidebar: View {
         VStack {
             EmptyStateView(component: .collection)
             Button {
-                editingCollection = nil
-                presentCollectionEdition = true
+                editCollection(editingCollection: nil)
             } label: {
                 Text(NSLocalizedString("criar_colecao", bundle: .module, comment: ""))
             }
             .buttonStyle(LargeButtonStyle(isDisabled: false))
             .padding()
         }
+    }
+    
+    private func editCollection(editingCollection: DeckCollection?) {
+        self.editingCollection = editingCollection
+        presentCollectionEdition = true
     }
 }

--- a/Bird-Modules/Sources/AppFeature/Sidebar/CollectionsSidebar.swift
+++ b/Bird-Modules/Sources/AppFeature/Sidebar/CollectionsSidebar.swift
@@ -68,6 +68,15 @@ struct CollectionsSidebar: View {
                                 }
                             }
                         }
+                        .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                            Button {
+                                editingCollection = collection
+                                presentCollectionEdition = true
+                            } label: {
+                                Text("editar", bundle: .module)
+                            }
+                            .tint(HBColor.actionColor)
+                        }
                         .listRowBackground(
                             isCompact ? HBColor.secondaryBackground : nil
                         )

--- a/Bird-Modules/Sources/NewDeckFeature/NewDeckView.swift
+++ b/Bird-Modules/Sources/NewDeckFeature/NewDeckView.swift
@@ -10,7 +10,6 @@ import HummingBird
 import Models
 import Storage
 import Habitat
-import DeckFeature
 
 public struct NewDeckView: View {
     @StateObject private var viewModel: NewDeckViewModel = NewDeckViewModel()

--- a/Bird-Modules/Sources/NewDeckFeature/NewDeckView.swift
+++ b/Bird-Modules/Sources/NewDeckFeature/NewDeckView.swift
@@ -10,6 +10,7 @@ import HummingBird
 import Models
 import Storage
 import Habitat
+import DeckFeature
 
 public struct NewDeckView: View {
     @StateObject private var viewModel: NewDeckViewModel = NewDeckViewModel()

--- a/Bird-Modules/Sources/StoreFeature/StoreViewModel.swift
+++ b/Bird-Modules/Sources/StoreFeature/StoreViewModel.swift
@@ -24,6 +24,7 @@ public class StoreViewModel: ObservableObject {
     func startup() {
         externalDeckService
             .getDeckFeed()
+            .receive(on: RunLoop.main)
             .handleEvents(receiveOutput: {[weak self] _ in
                 self?.viewState = .loaded
             }, receiveCompletion: {[weak self] completion in


### PR DESCRIPTION
- Na tela de coleções, inseri um swipe para a direita para editar e para esquerda para deletar
- Os mesmos swipes para os decks
- Refatoração para a ação de editar o deck e chamar o sheet, criando uma função para isso 

<img width="596" alt="image" src="https://user-images.githubusercontent.com/49920539/199332305-396e166f-de6e-4f8e-9694-74eed669eba3.png">

<img width="596" alt="image" src="https://user-images.githubusercontent.com/49920539/199332343-3e3c9152-baf9-43b8-a5a4-6b4779c431eb.png">

